### PR TITLE
initial implementation

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,20 @@
+#
+# Build and test on pull request
+#
+name: Pull Request
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.5'
+      - name: Build
+        run: go build -v

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Build and Test
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
@@ -17,4 +17,6 @@ jobs:
         with:
           go-version: '1.13.5'
       - name: Build
-        run: go build -v
+        run: go build -v ./...
+      - name: Test
+        run: go test -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # OS Generated files
 .DS_Store
-
+ 
 # Temporary files
-.*.swp
+*.swp
+
+# IDE files
+/.idea

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -5,17 +5,18 @@ For general information about contributing changes, see the
 
 ## How it Works
 
-Describe the internal mechanisms necessary for developers to understand how
-to get started making changes.
+The Remote SDK currently provides interfaces only for use by the client. This includes the ability to register
+remote providers, and parse URIs. Future work will add server-side capabilities for use in titan-server, enabling
+the EOL of the legacy kotlin remote providers.
 
 ## Building
 
-Describe how to build the project.
+Run `go build -v ./...`.
 
 ## Testing
 
-Describe how to test the project.
+Run `go test -v ./...`.
 
 ## Releasing
 
-Describe how to generate new releases.
+Push a tag of the form `v<X>.<Y>.<Z>`, and publish the draft release in GitHub.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # About this Project
 
-Describe the project for users.
+This project provides a common set of interfaces for remote providers (such
+as SSH and S3). Titan does not yet provide a way to dynamically load
+remote providers, but this SDK provides a means for providers to have their
+own dedicated repositories.
 
 ## Contributing
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/titan-data/titan-client-go
 
+require github.com/stretchr/testify v1.4.0
+
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/titan-data/titan-client-go
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -64,4 +64,3 @@ func Get(remoteType string) Remote {
 func Clear() {
 	registeredRemotes = map[string]Remote{}
 }
-

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+package remote
+
+import "net/url"
+
+/*
+ * SDK for Titan remotes. Currently supports only client-side remote actions (parsing URIs and creating parameter
+ * objects).
+ */
+
+type Remote interface {
+
+	/*
+	 * Returns the canonical name of this provider, such as "ssh" or "s3". This must be globally unique, and must
+	 * match the leading URI component (ssh://...).
+	 */
+	Type() string
+
+	/*
+	 * Parse a URL and return the provider-specific remote parameters in structured form. These properties will be
+	 * preserved as part of the remote metadata on the server and passed to subsequent server-side operations. The
+	 * additional properties map can contain properties specified by the user that don't fit the URI format well,
+	 * such as "-p keyFile=/path/to/sshKey". This should return an error a bad URL format or invalid properties.
+	 */
+	FromURL(url url.URL, additionalProperties map[string]string) (map[string]interface{}, error)
+
+	/*
+	 * Convert a remote back into URI form for display. Since this is for display only, any sensitive information
+	 * should be redacted (e.g. "user:****@host"). Any properties that cannot be represented in the URI can be
+	 * passed back as the second part of the pair.
+	 */
+	ToURL(properties map[string]interface{}) (string, map[string]string, error)
+
+	/*
+	 * Given a set of remote properties, return a set of parameter properties that will be passed to each operation.
+	 * This is invoked in the context of the user CLI. It can access user data, such as SSH or AWS configuration. It
+	 * can also interactively prompt the user for additional input (such as a password).
+	 */
+	GetParameters(remoteProperties map[string]interface{}) (map[string]interface{}, error)
+}
+
+var registeredRemotes = map[string]Remote{}
+
+/*
+ * Register a new remote. This should be called from the init() function of a remote implementation. The remotes can
+ * later be accessed via the Get() method.
+ */
+func Register(remote Remote) {
+	registeredRemotes[remote.Type()] = remote
+}
+
+/*
+ * Get a remote by type.
+ */
+func Get(remoteType string) Remote {
+	return registeredRemotes[remoteType]
+}

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -57,3 +57,11 @@ func Register(remote Remote) {
 func Get(remoteType string) Remote {
 	return registeredRemotes[remoteType]
 }
+
+/*
+ * Clear any registered remotes. Should only be used for testing.
+ */
+func Clear() {
+	registeredRemotes = map[string]Remote{}
+}
+

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -44,4 +44,3 @@ func TestRegister(t *testing.T) {
 	assert.Equal(t, "mock", res.Type())
 	r.AssertExpectations(t)
 }
-

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+package remote
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"net/url"
+	"testing"
+)
+
+type MockRemote struct {
+	mock.Mock
+}
+
+func (r *MockRemote) Type() string {
+	args := r.Called()
+	return args.String(0)
+}
+
+func (r *MockRemote) FromURL(url url.URL, additionalProperties map[string]string) (map[string]interface{}, error) {
+	args := r.Called(url, additionalProperties)
+	return args.Get(0).(map[string]interface{}), args.Error(1)
+}
+
+func (r *MockRemote) ToURL(properties map[string]interface{}) (string, map[string]string, error) {
+	args := r.Called(properties)
+	return args.String(0), args.Get(1).(map[string]string), args.Error(2)
+}
+
+func (r *MockRemote) GetParameters(remoteProperties map[string]interface{}) (map[string]interface{}, error) {
+	args := r.Called(remoteProperties)
+	return args.Get(0).(map[string]interface{}), args.Error(1)
+}
+
+func TestRegister(t *testing.T) {
+	Clear()
+	r := new(MockRemote)
+	r.On("Type").Return("mock")
+	Register(r)
+
+	res := Get("mock")
+	assert.Equal(t, "mock", res.Type())
+	r.AssertExpectations(t)
+}
+


### PR DESCRIPTION
## Proposed Changes

This is an initial implementation of the remote SDK provider. It's bare-bones, with just an interface and the ability to register remote providers. This will grow as we add additional capabilities and validate with real-world implementations.

## Testing

`go test -v ./...`.