### PR TITLE
quality of life improvements

### DIFF
--- a/remote/mock_test.go
+++ b/remote/mock_test.go
@@ -1,3 +1,6 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
 package remote
 
 import (

--- a/remote/mock_test.go
+++ b/remote/mock_test.go
@@ -34,4 +34,3 @@ func (r *MockRemote) GetParameters(remoteProperties map[string]interface{}) (map
 	args := r.Called(remoteProperties)
 	return args.Get(0).(map[string]interface{}), args.Error(1)
 }
-

--- a/remote/mock_test.go
+++ b/remote/mock_test.go
@@ -1,17 +1,15 @@
-/*
- * Copyright The Titan Project Contributors.
- */
 package remote
 
 import (
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"net/url"
-	"testing"
 )
 
 type MockRemote struct {
 	mock.Mock
+
+	u     *url.URL
+	props map[string]string
 }
 
 func (r *MockRemote) Type() string {
@@ -19,7 +17,10 @@ func (r *MockRemote) Type() string {
 	return args.String(0)
 }
 
-func (r *MockRemote) FromURL(url url.URL, additionalProperties map[string]string) (map[string]interface{}, error) {
+func (r *MockRemote) FromURL(url *url.URL, additionalProperties map[string]string) (map[string]interface{}, error) {
+	r.u = url
+	r.props = additionalProperties
+
 	args := r.Called(url, additionalProperties)
 	return args.Get(0).(map[string]interface{}), args.Error(1)
 }
@@ -34,13 +35,3 @@ func (r *MockRemote) GetParameters(remoteProperties map[string]interface{}) (map
 	return args.Get(0).(map[string]interface{}), args.Error(1)
 }
 
-func TestRegister(t *testing.T) {
-	Clear()
-	r := new(MockRemote)
-	r.On("Type").Return("mock")
-	Register(r)
-
-	res := Get("mock")
-	assert.Equal(t, "mock", res.Type())
-	r.AssertExpectations(t)
-}

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -24,7 +24,7 @@ type Remote interface {
 	 * additional properties map can contain properties specified by the user that don't fit the URI format well,
 	 * such as "-p keyFile=/path/to/sshKey". This should return an error a bad URL format or invalid properties.
 	 */
-	FromURL(url url.URL, additionalProperties map[string]string) (map[string]interface{}, error)
+	FromURL(url *url.URL, additionalProperties map[string]string) (map[string]interface{}, error)
 
 	/*
 	 * Convert a remote back into URI form for display. Since this is for display only, any sensitive information

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -1,0 +1,20 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+package remote
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestRegister(t *testing.T) {
+	Clear()
+	r := new(MockRemote)
+	r.On("Type").Return("mock")
+	Register(r)
+
+	res := Get("mock")
+	assert.Equal(t, "mock", res.Type())
+	r.AssertExpectations(t)
+}

--- a/remote/util.go
+++ b/remote/util.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+package remote
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+/*
+ * Wrap remote URL parsing in an easier-to use function that will handle converting to the intermediate URL format,
+ * processing any query parameters (for tags) and fragment (for commit IDs).
+ */
+func ParseURL(input string, properties map[string]string) (string, map[string]interface{}, []string, string, error) {
+	u, err := url.Parse(input)
+	if err != nil {
+		return "", nil, nil, "", err
+	}
+
+	var provider string
+	if u.Scheme != "" {
+		provider = u.Scheme
+	} else {
+		provider = u.Path
+	}
+
+	var r = Get(provider)
+	if r == nil {
+		return "", nil, nil, "", errors.New(fmt.Sprintf("unknown remote provider '%s'", provider))
+	}
+
+	commit := u.Fragment
+	tags := []string{}
+	for k := range u.Query() {
+		if k != "tag" {
+			return "", nil, nil, "", errors.New(fmt.Sprintf("invalid query parameter '%s'", k))
+		}
+	}
+	if u.Query()["tag"] != nil {
+		tags = u.Query()["tag"]
+	}
+
+	props, err := r.FromURL(u, properties)
+	if err != nil {
+		return "", nil, nil, "", err
+	}
+
+	return provider, props, tags, commit, nil
+}

--- a/remote/util_test.go
+++ b/remote/util_test.go
@@ -1,3 +1,6 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
 package remote
 
 import (

--- a/remote/util_test.go
+++ b/remote/util_test.go
@@ -1,0 +1,125 @@
+package remote
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+func registerDefaultRemote() *MockRemote {
+	Clear()
+	r := new(MockRemote)
+	r.On("Type").Return("mock")
+	r.On("FromURL", mock.Anything, mock.Anything).Return(map[string]interface{}{}, nil)
+	Register(r)
+	return r
+}
+
+func TestProvider(t *testing.T) {
+	r := registerDefaultRemote()
+	provider, _, _, _, _ := ParseURL("mock", map[string]string{})
+	assert.Equal(t, "mock", provider)
+	r.AssertExpectations(t)
+}
+
+func TestBadProvider(t *testing.T) {
+	_ = registerDefaultRemote()
+	_, _, _, _, err := ParseURL("notmock", map[string]string{})
+	assert.NotNil(t, err)
+}
+
+func TestBadURL(t *testing.T) {
+	_ = registerDefaultRemote()
+	_, _, _, _, err := ParseURL("a\000b", map[string]string{})
+	assert.NotNil(t, err)
+}
+
+func TestProviderScheme(t *testing.T) {
+	r := registerDefaultRemote()
+	provider, _, _, _, _ := ParseURL("mock://foo", map[string]string{})
+	assert.Equal(t, "mock", provider)
+	r.AssertExpectations(t)
+}
+
+func TestFragment(t *testing.T) {
+	r := registerDefaultRemote()
+	_, _, _, commit, _ := ParseURL("mock://foo#commit", map[string]string{})
+	assert.Equal(t, "commit", commit)
+	r.AssertExpectations(t)
+}
+
+func TestNoFragment(t *testing.T) {
+	r := registerDefaultRemote()
+	_, _, _, commit, _ := ParseURL("mock://foo", map[string]string{})
+	assert.Empty(t, commit)
+	r.AssertExpectations(t)
+}
+
+func TestQueryParams(t *testing.T) {
+	r := registerDefaultRemote()
+	_, _, tags, _, _ := ParseURL("mock://foo?tag=one&tag=two=three", map[string]string{})
+	assert.Len(t, tags, 2)
+	assert.Equal(t, "one", tags[0])
+	assert.Equal(t, "two=three", tags[1])
+	r.AssertExpectations(t)
+}
+
+func TestBadQueryParams(t *testing.T) {
+	_ = registerDefaultRemote()
+	_, _, _, _, err := ParseURL("mock://foo?nottag=one", map[string]string{})
+	assert.NotNil(t, err)
+}
+
+func TestEmptyQueryParams(t *testing.T) {
+	r := registerDefaultRemote()
+	_, _, tags, _, _ := ParseURL("mock://foo", map[string]string{})
+	assert.Empty(t, tags)
+	r.AssertExpectations(t)
+}
+
+func TestProperties(t *testing.T) {
+	Clear()
+	r := new(MockRemote)
+	r.On("Type").Return("mock")
+	r.On("FromURL", mock.Anything, mock.Anything).Return(map[string]interface{}{"a": "b"}, nil)
+	Register(r)
+
+	_, props, _, _, _ := ParseURL("mock://foo", map[string]string{})
+	assert.Len(t, props, 1)
+	assert.Equal(t, "b", props["a"])
+	r.AssertExpectations(t)
+}
+
+func TestBadProperties(t *testing.T) {
+	Clear()
+	r := new(MockRemote)
+	r.On("Type").Return("mock")
+	r.On("FromURL", mock.Anything, mock.Anything).Return(map[string]interface{}{}, errors.New("error"))
+	Register(r)
+
+	_, _, _, _, err := ParseURL("mock://foo", map[string]string{})
+	assert.NotNil(t, err)
+	r.AssertExpectations(t)
+}
+
+func TestProviderArguments(t *testing.T) {
+	Clear()
+	r := new(MockRemote)
+	r.On("Type").Return("mock")
+	r.On("FromURL", mock.Anything, mock.Anything).Return(map[string]interface{}{}, nil)
+	Register(r)
+
+	_, _, _, _, _ = ParseURL("mock://user:pass@host:80/path", map[string]string{"a": "b"})
+	assert.Len(t, r.props, 1)
+	assert.Equal(t, "b", r.props["a"])
+	assert.Equal(t, "mock", r.u.Scheme)
+	assert.Equal(t, "host", r.u.Hostname())
+	assert.Equal(t, "80", r.u.Port())
+	assert.Equal(t, "/path", r.u.Path)
+	assert.Equal(t, "user", r.u.User.Username())
+	pass, set := r.u.User.Password()
+	assert.Equal(t, "pass", pass)
+	assert.True(t, set)
+	r.AssertExpectations(t)
+}


### PR DESCRIPTION
## Proposed Changes

This fixes a few things encountered when starting to implement remote go providers:

- Putting everything under "pkg", while recommended by the go project structure best practices, introduces a required "<url>/pkg/remote" that is non-obvious and isn't something that other go packages seem to do.
- The golang net.utl methods return pointers to URLs, so the remote interface should consume that to avoid unnecessary dereferences.
- The remotes make some assumptions about how things like the provider type is determined, and rather than having the client contain that knowledge I added a `ParseURL` method that will figure out the right provider, handle tag query parameters, etc. Should make it much easier for the CLI.

## Testing

`go test -v ./...` and verified 100% coverage.