### PR TITLE
tags should should string -> interface

### DIFF
--- a/internal/echo/echo.go
+++ b/internal/echo/echo.go
@@ -45,10 +45,10 @@ func (m EchoRemote) ValidateParameters(parameters map[string]interface{}) error 
 func (m EchoRemote) ListCommits(properties map[string]interface{}, parameters map[string]interface{}, tags []remote.Tag) ([]remote.Commit, error) {
 	res := []remote.Commit{{
 		Id:         "one",
-		Properties: map[string]interface{}{"tags": map[string]string{"name": "one"}, "timestamp": "2019-09-20T13:45:36Z"},
+		Properties: map[string]interface{}{"tags": map[string]interface{}{"name": "one"}, "timestamp": "2019-09-20T13:45:36Z"},
 	}, {
 		Id:         "two",
-		Properties: map[string]interface{}{"tags": map[string]string{"name": "two"}, "timestamp": "2019-09-20T13:45:37Z"},
+		Properties: map[string]interface{}{"tags": map[string]interface{}{"name": "two"}, "timestamp": "2019-09-20T13:45:37Z"},
 	}}
 	n := 0
 	for _, c := range res {

--- a/internal/echo/echo_test.go
+++ b/internal/echo/echo_test.go
@@ -64,9 +64,9 @@ func TestListCommits(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Len(t, commits, 2)
 		assert.Equal(t, "two", commits[0].Id)
-		assert.Equal(t, "two", commits[0].Properties["tags"].(map[string]string)["name"])
+		assert.Equal(t, "two", commits[0].Properties["tags"].(map[string]interface{})["name"])
 		assert.Equal(t, "one", commits[1].Id)
-		assert.Equal(t, "one", commits[1].Properties["tags"].(map[string]string)["name"])
+		assert.Equal(t, "one", commits[1].Properties["tags"].(map[string]interface{})["name"])
 	}
 }
 

--- a/remote/util.go
+++ b/remote/util.go
@@ -124,8 +124,12 @@ func MatchTags(commit map[string]interface{}, query []Tag) bool {
 	}
 
 	var ok bool
-	var tags map[string]interface{}
-	if tags, ok = commit["tags"].(map[string]interface{}); !ok {
+	tags := map[string]string{}
+	if raw, ok := commit["tags"].(map[string]interface{}); ok {
+		for k, v := range raw {
+			tags[k] = v.(string)
+		}
+	}  else if tags, ok = commit["tags"].(map[string]string); !ok {
 		return false
 	}
 
@@ -135,7 +139,7 @@ func MatchTags(commit map[string]interface{}, query []Tag) bool {
 			return false
 		}
 
-		if t.Value != nil && v.(string) != *t.Value {
+		if t.Value != nil && v != *t.Value {
 			return false
 		}
 	}

--- a/remote/util.go
+++ b/remote/util.go
@@ -124,18 +124,18 @@ func MatchTags(commit map[string]interface{}, query []Tag) bool {
 	}
 
 	var ok bool
-	var tags map[string]string
-	if tags, ok = commit["tags"].(map[string]string); !ok {
+	var tags map[string]interface{}
+	if tags, ok = commit["tags"].(map[string]interface{}); !ok {
 		return false
 	}
 
 	for _, t := range query {
-		var v string
+		var v interface{}
 		if v, ok = tags[t.Key]; !ok {
 			return false
 		}
 
-		if t.Value != nil && v != *t.Value {
+		if t.Value != nil && v.(string) != *t.Value {
 			return false
 		}
 	}

--- a/remote/util_test.go
+++ b/remote/util_test.go
@@ -126,7 +126,11 @@ func makeCommit(props map[string]string) map[string]interface{} {
 	if len(props) == 0 {
 		return map[string]interface{}{}
 	} else {
-		return map[string]interface{}{"tags": props}
+		p := map[string]interface{}{}
+		for k, v := range props {
+			p[k] = v
+		}
+		return map[string]interface{}{"tags": p}
 	}
 }
 

--- a/remote/util_test.go
+++ b/remote/util_test.go
@@ -126,11 +126,7 @@ func makeCommit(props map[string]string) map[string]interface{} {
 	if len(props) == 0 {
 		return map[string]interface{}{}
 	} else {
-		p := map[string]interface{}{}
-		for k, v := range props {
-			p[k] = v
-		}
-		return map[string]interface{}{"tags": p}
+		return map[string]interface{}{"tags": props}
 	}
 }
 
@@ -154,6 +150,11 @@ func TestMatchExact(t *testing.T) {
 	assert.True(t, MatchTags(makeCommit(map[string]string{"a": "b"}), tags))
 	assert.False(t, MatchTags(makeCommit(map[string]string{"a": "B"}), tags))
 	assert.False(t, MatchTags(makeCommit(map[string]string{"c": "d"}), tags))
+}
+
+func TestMatchInterface(t *testing.T) {
+	tags := []Tag{exactTag("a", "b")}
+	assert.True(t, MatchTags(map[string]interface{}{"tags": map[string]interface{}{"a": "b"}}, tags))
 }
 
 func TestMatchExistence(t *testing.T) {


### PR DESCRIPTION
## Proposed Changes

When writing the original go SDK, the tags were assumed to be `map[string]string`. When unmarshalling JSON, this will actually be `map[string]interface{}`. This updates to support both, as we can't be sure exactly how the remotes will choose to store their commit information.

## Testing

`go test ./...`